### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,19 +16,19 @@ Links
 - Feel free to `tip me <https://gratipay.com/femtotrader/>`__!
 - Official Pandas DataReader can be found at https://github.com/pydata/pandas-datareader
 
-.. |Latest Version| image:: https://pypip.in/version/pandas_datareaders_unofficial/badge.svg
+.. |Latest Version| image:: https://img.shields.io/pypi/v/pandas_datareaders_unofficial.svg
     :target: https://pypi.python.org/pypi/pandas_datareaders_unofficial/
 
-.. |Supported Python versions| image:: https://pypip.in/py_versions/pandas_datareaders_unofficial/badge.svg
+.. |Supported Python versions| image:: https://img.shields.io/pypi/pyversions/pandas_datareaders_unofficial.svg
     :target: https://pypi.python.org/pypi/pandas_datareaders_unofficial/
 
-.. |Download format| image:: https://pypip.in/format/pandas_datareaders_unofficial/badge.svg
+.. |Download format| image:: https://img.shields.io/pypi/format/pandas_datareaders_unofficial.svg
     :target: https://pypi.python.org/pypi/pandas_datareaders_unofficial/
 
-.. |License| image:: https://pypip.in/license/pandas_datareaders_unofficial/badge.svg
+.. |License| image:: https://img.shields.io/pypi/l/pandas_datareaders_unofficial.svg
     :target: https://pypi.python.org/pypi/pandas_datareaders_unofficial/
 
-.. |Development Status| image:: https://pypip.in/status/pandas_datareaders_unofficial/badge.svg
+.. |Development Status| image:: https://img.shields.io/pypi/status/pandas_datareaders_unofficial.svg
     :target: https://pypi.python.org/pypi/pandas_datareaders_unofficial/
 
 .. |Gitter| image:: https://badges.gitter.im/Join%20Chat.svg


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20pandas-datareaders-unofficial))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `pandas-datareaders-unofficial`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.